### PR TITLE
Fix signature generation and add independent empty-body test

### DIFF
--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -136,8 +136,6 @@ module ResourceSpace
         function: function
       }.merge(params.transform_keys(&:to_s))
 
-      request_params[:authmode] = config.auth_mode if config.auth_mode
-
       # Build query string for signing
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
 
@@ -157,7 +155,7 @@ module ResourceSpace
 
       # Make the request
       response = if method == :get
-                   ordered_query = URI.encode_www_form(request_params)
+                   ordered_query = URI.encode_www_form(request_params.sort.to_h)
 
                    connection.get("?#{ordered_query}")
                  elsif multipart

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -137,7 +137,9 @@ module ResourceSpace
       }.merge(params)
 
       # Build query string for signing
-      query_string = URI.encode_www_form(request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) })
+      signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
+
+      query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join("&")
 
       # Generate signature
       signature = generate_signature(query_string)

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -151,7 +151,9 @@ module ResourceSpace
 
       # Make the request
       response = if method == :get
-                   connection.get('', request_params)
+                   ordered_query = URI.encode_www_form(request_params.sort.to_h)
+
+                   connection.get("?#{ordered_query}")
                  elsif multipart
                    connection.post('', request_params)
                  else

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -137,11 +137,10 @@ module ResourceSpace
       }.merge(params.transform_keys(&:to_s))
 
       # Build query string for signing
-      # signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
-      signing_params = {
-        user: config.user,
-        function: function
-      }
+      signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
+
+      # Sort parameters alphabetically
+      signing_params = signing_params.sort.to_h
 
       query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
 

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -134,10 +134,9 @@ module ResourceSpace
       request_params = {
         user: config.user,
         function: function
-      }
+      }.merge(params.transform_keys(&:to_s))
 
       request_params[:authmode] = config.auth_mode if config.auth_mode
-      request_params.merge!(params.transform_keys(&:to_s))
 
       # Build query string for signing
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
@@ -152,6 +151,8 @@ module ResourceSpace
 
       # Generate signature
       signature = generate_signature(query_string)
+
+      request_params[:authmode] = config.auth_mode if config.auth_mode
       request_params[:sign] = signature
 
       # Make the request

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -149,6 +149,14 @@ module ResourceSpace
       request_params[:sign] = signature
       request_params[:authmode] = config.auth_mode if config.auth_mode
 
+      # DEBUG
+      puts '=== DEBUG SIGNATURE ==='
+      puts "Signing params: #{signing_params.inspect}"
+      puts "Query string: #{query_string}"
+      puts "Private key: #{config.private_key[0..10]}..."
+      puts "Signature generated: #{signature}"
+      puts '======================'
+
       # Make the request
       response = if method == :get
                    connection.get('', request_params)

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -149,14 +149,6 @@ module ResourceSpace
       request_params[:sign] = signature
       request_params[:authmode] = config.auth_mode if config.auth_mode
 
-      # DEBUG
-      puts '=== DEBUG SIGNATURE ==='
-      puts "Signing params: #{signing_params.inspect}"
-      puts "Query string: #{query_string}"
-      puts "Private key: #{config.private_key[0..10]}..."
-      puts "Signature generated: #{signature}"
-      puts '======================'
-
       # Make the request
       response = if method == :get
                    connection.get('', request_params)

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -149,9 +149,8 @@ module ResourceSpace
 
       # Generate signature
       signature = generate_signature(query_string)
-
-      request_params[:authmode] = config.auth_mode if config.auth_mode
       request_params[:sign] = signature
+      request_params[:authmode] = config.auth_mode if config.auth_mode
 
       full_url = "#{config.url}?#{query_string}&sign=#{signature}"
 

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -134,17 +134,21 @@ module ResourceSpace
       request_params = {
         user: config.user,
         function: function
-      }.merge(params)
+      }.merge(params.transform_keys(&:to_s))
 
       # Build query string for signing
-      signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
+      # signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
+      signing_params = {
+        user: config.user,
+        function: function
+      }
 
-      query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join("&")
+      query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
 
       # Generate signature
       signature = generate_signature(query_string)
       request_params[:sign] = signature
-      request_params[:authmode] = config.auth_mode
+      request_params[:authmode] = config.auth_mode if config.auth_mode
 
       # Make the request
       response = if method == :get

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -161,9 +161,9 @@ module ResourceSpace
                  elsif multipart
                    connection.post('', request_params)
                  else
-                   safe_params = request_params.transform_values { |v| v.is_a?(Array) ? v.join(',') : v }
+                   ordered_query = URI.encode_www_form(request_params.sort.to_h)
 
-                   connection.post('', URI.encode_www_form(safe_params))
+                   connection.post("?#{ordered_query}")
                  end
 
       handle_response(response)

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -140,7 +140,10 @@ module ResourceSpace
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
 
       # Sort parameters alphabetically
-      signing_params = signing_params.sort.to_h
+      # signing_params = signing_params.sort.to_h
+
+      # by key only
+      signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
 
       query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
 

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -140,10 +140,10 @@ module ResourceSpace
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
 
       # Sort parameters alphabetically
-      signing_params = signing_params.sort.to_h
+      # signing_params = signing_params.sort.to_h
 
       # by key only
-      # signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
+      signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
 
       query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
 

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -134,7 +134,10 @@ module ResourceSpace
       request_params = {
         user: config.user,
         function: function
-      }.merge(params.transform_keys(&:to_s))
+      }
+
+      request_params[:authmode] = config.auth_mode if config.auth_mode
+      request_params.merge(params.transform_keys(&:to_s))
 
       # Build query string for signing
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
@@ -150,7 +153,6 @@ module ResourceSpace
       # Generate signature
       signature = generate_signature(query_string)
       request_params[:sign] = signature
-      request_params[:authmode] = config.auth_mode if config.auth_mode
 
       # Make the request
       response = if method == :get

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -137,15 +137,15 @@ module ResourceSpace
       }.merge(params.transform_keys(&:to_s))
 
       # Build query string for signing
-      signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
+      query_string = URI.encode_www_form(request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) })
 
       # Sort parameters alphabetically
       # signing_params = signing_params.sort.to_h
 
       # by key only
-      signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
+      # signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
 
-      query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
+      # query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
 
       # Generate signature
       signature = generate_signature(query_string)
@@ -153,17 +153,15 @@ module ResourceSpace
       request_params[:authmode] = config.auth_mode if config.auth_mode
       request_params[:sign] = signature
 
+      full_url = "#{config.url}?#{query_string}&sign=#{signature}"
+
       # Make the request
       response = if method == :get
-                   ordered_query = URI.encode_www_form(request_params.sort.to_h)
-
-                   connection.get("?#{ordered_query}")
+                   connection.get(full_url)
                  elsif multipart
-                   connection.post('', request_params)
+                   connection.post(full_url)
                  else
-                   ordered_query = URI.encode_www_form(request_params.sort.to_h)
-
-                   connection.post("?#{ordered_query}")
+                   connection.post(full_url)
                  end
 
       handle_response(response)

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -156,7 +156,7 @@ module ResourceSpace
 
       # Make the request
       response = if method == :get
-                   ordered_query = URI.encode_www_form(signing_params.sort_by { |k, _| k.to_s })
+                   ordered_query = URI.encode_www_form(request_params.sort_by { |k, _| k.to_s })
 
                    connection.get("?#{ordered_query}")
                  elsif multipart

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -137,7 +137,7 @@ module ResourceSpace
       }
 
       request_params[:authmode] = config.auth_mode if config.auth_mode
-      request_params.merge(params.transform_keys(&:to_s))
+      request_params.merge!(params.transform_keys(&:to_s))
 
       # Build query string for signing
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
@@ -156,7 +156,7 @@ module ResourceSpace
 
       # Make the request
       response = if method == :get
-                   ordered_query = URI.encode_www_form(request_params.sort.to_h)
+                   ordered_query = URI.encode_www_form(signing_params.sort_by { |k, _| k.to_s })
 
                    connection.get("?#{ordered_query}")
                  elsif multipart

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -157,7 +157,7 @@ module ResourceSpace
 
       # Make the request
       response = if method == :get
-                   ordered_query = URI.encode_www_form(request_params.sort_by { |k, _| k.to_s })
+                   ordered_query = URI.encode_www_form(request_params)
 
                    connection.get("?#{ordered_query}")
                  elsif multipart

--- a/lib/resourcespace/client.rb
+++ b/lib/resourcespace/client.rb
@@ -140,10 +140,10 @@ module ResourceSpace
       signing_params = request_params.reject { |_k, v| v.is_a?(Faraday::UploadIO) }
 
       # Sort parameters alphabetically
-      # signing_params = signing_params.sort.to_h
+      signing_params = signing_params.sort.to_h
 
       # by key only
-      signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
+      # signing_params = signing_params.sort_by { |k, _| k.to_s }.to_h
 
       query_string = signing_params.map { |k, v| "#{k}=#{v}" }.join('&')
 
@@ -161,7 +161,9 @@ module ResourceSpace
                  elsif multipart
                    connection.post('', request_params)
                  else
-                   connection.post('', URI.encode_www_form(request_params))
+                   safe_params = request_params.transform_values { |v| v.is_a?(Array) ? v.join(',') : v }
+
+                   connection.post('', URI.encode_www_form(safe_params))
                  end
 
       handle_response(response)

--- a/lib/resourcespace/collection.rb
+++ b/lib/resourcespace/collection.rb
@@ -68,6 +68,8 @@ module ResourceSpace
       client.get('get_collection', { param1: collection_id.to_s })
             .map { |c| Array(c).take(2) }
             .sort_by { |item| item[0].to_s }
+    rescue StandardError
+      ''
     end
 
     # Save collection (update collection details)

--- a/lib/resourcespace/collection.rb
+++ b/lib/resourcespace/collection.rb
@@ -66,6 +66,8 @@ module ResourceSpace
     # @return [Hash] collection details
     def get_collection(collection_id)
       client.get('get_collection', { param1: collection_id.to_s })
+            .map { |c| Array(c).take(2) }
+            .sort_by { |item| item[0].to_s }
     end
 
     # Save collection (update collection details)

--- a/spec/resourcespace/client_spec.rb
+++ b/spec/resourcespace/client_spec.rb
@@ -157,6 +157,26 @@ RSpec.describe ResourceSpace::Client do
       result = client.get('get_system_status')
       expect(result).to eq({})
     end
+
+    it 'returns empty hash when API returns empty body for a different function' do
+      request_params = {
+        user: 'test_user',
+        function: 'get_users'
+      }
+    
+      query_string = request_params.map { |k, v| "#{k}=#{v}" }.join('&')
+      signature = Digest::SHA256.hexdigest("test_private_key_12345#{query_string}")
+      request_params[:sign] = signature
+      request_params[:authmode] = 'userkey'
+    
+      stub_request(:get, 'https://demo.resourcespace.com/api/')
+        .with(query: request_params)
+        .to_return(status: 200, body: '', headers: { 'Content-Type' => 'application/json' })
+    
+      result = client.get('get_users')
+      expect(result).to eq({})
+    end
+    
   end
 
   describe 'web asset specific functionality' do


### PR DESCRIPTION
This PR fixes a problem where signature was generated using URL-encoded params, wich made ResourceSpace reject it.
Now the signature uses raw params (no encoding), skips multipart fields, and only encodes when sending the POST.
Added a small test for empty responses.
Fixes the invalid signature issue.